### PR TITLE
Fix SFMA library highlighting priority and null pointer guard

### DIFF
--- a/src/lib/model/library/librarylistviewmodel.cpp
+++ b/src/lib/model/library/librarylistviewmodel.cpp
@@ -193,6 +193,14 @@ QVariant LibraryListViewModel::data(const QModelIndex &index, int role) const
                     _mediaLibraryHandler->getLibraryCache()->unlock();
                     return QColor(Qt::GlobalColor::red);
                 }
+                if(item.metadata.isSFMA) {
+                    _mediaLibraryHandler->getLibraryCache()->unlock();
+                    return QColor(Qt::GlobalColor::yellow);
+                }
+                if(item.metadata.isMFS && item.hasScript) {
+                    _mediaLibraryHandler->getLibraryCache()->unlock();
+                    return QColor(Qt::green);
+                }
                 if (!item.hasScript && item.metadata.isMFS) {
                     _mediaLibraryHandler->getLibraryCache()->unlock();
                     return QColor(Qt::GlobalColor::cyan);
@@ -200,14 +208,6 @@ QVariant LibraryListViewModel::data(const QModelIndex &index, int role) const
                 if (!item.hasScript) {
                     _mediaLibraryHandler->getLibraryCache()->unlock();
                     return QColor(Qt::gray);
-                }
-                if(item.metadata.isSFMA) {
-                    _mediaLibraryHandler->getLibraryCache()->unlock();
-                    return QColor(Qt::GlobalColor::yellow);
-                }
-                if(item.metadata.isMFS) {
-                    _mediaLibraryHandler->getLibraryCache()->unlock();
-                    return QColor(Qt::green);
                 }
             }
         }

--- a/src/settingsdialog.cpp
+++ b/src/settingsdialog.cpp
@@ -337,7 +337,8 @@ void SettingsDialog::setupUi()
         ui.webAddressInstructionsLabel->setVisible(SettingsHandler::getEnableHttpServer());
         ui.webAddressLinkLabel->setVisible(SettingsHandler::getEnableHttpServer());
         ui.httpRootLineEdit->setText(SettingsHandler::getHttpServerRoot());
-        ui.vrLibraryLineEdit->setText(SettingsHandler::mediaLibrarySettings->getLast(LibraryType::VR));
+        if(SettingsHandler::mediaLibrarySettings)
+            ui.vrLibraryLineEdit->setText(SettingsHandler::mediaLibrarySettings->getLast(LibraryType::VR));
         ui.chunkSizeDoubleSpinBox->setValue(SettingsHandler::getHTTPChunkSizeMB());
         ui.httpPortSpinBox->setValue(SettingsHandler::getHTTPPort());
         ui.webSocketPortSpinBox->setValue(SettingsHandler::getWebSocketPort());


### PR DESCRIPTION
## Summary

Two fixes for the XTPlayer UI on modern GCC (14.x):

### 1. Fix SFMA multi-axis library highlighting

Reorder foreground color checks in `LibraryListViewModel` so SFMA (yellow) and MFS with hasScript (green) take priority over the `!hasScript` (gray) catch-all. Previously, SFMA items with script data were incorrectly shown as gray instead of yellow.

### 2. Guard null `mediaLibrarySettings` in SettingsDialog

GCC 14 with `-mno-direct-extern-access` can cause `static inline` variables to have different instances across shared library boundaries (fixed on the XTEngine side). As a defensive measure, add a null guard before dereferencing `mediaLibrarySettings` in `SettingsDialog::setupUi()`.

## Test plan

- [ ] Open library with SFMA funscripts — items should highlight in yellow
- [ ] Open library with MFS funscripts — items should highlight in green
- [ ] Open Settings dialog — should not crash
- [ ] Launch app and close welcome dialog — should not crash
